### PR TITLE
Fixed make errors on kernel 5.18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 facetimehd
 ==========
 
+## fixed make error on Linux 5.18+?
+(needs more help testing)
+
 Linux driver for the Facetime HD (Broadcom 1570) PCIe webcam
 found in recent Macbooks.
 

--- a/fthd_drv.c
+++ b/fthd_drv.c
@@ -12,6 +12,7 @@
 #include <linux/module.h>
 #include <linux/pci.h>
 #include <linux/version.h>
+#include <linux/dma-mapping.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
 #include <linux/pci-aspm.h>
 #endif
@@ -396,7 +397,7 @@ static int fthd_pci_init(struct fthd_private *dev_priv)
 		goto fail_irq;
 
 	dev_info(&pdev->dev, "Setting %ubit DMA mask\n", dev_priv->dma_mask);
-	pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(dev_priv->dma_mask));
+	dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(dev_priv->dma_mask));
 
 	pci_set_master(pdev);
 	pci_set_drvdata(pdev, dev_priv);

--- a/fthd_drv.h
+++ b/fthd_drv.h
@@ -15,6 +15,7 @@
 #include <linux/wait.h>
 #include <linux/mutex.h>
 #include <linux/version.h>
+#include <linux/dma-mapping.h>
 #include <media/videobuf2-dma-sg.h>
 #include <media/v4l2-device.h>
 #include <media/v4l2-ctrls.h>


### PR DESCRIPTION
Tested on Archlinux with stable and zen kernel 5.18