### PR TITLE
v4l2: drop ref to unused header

### DIFF
--- a/fthd_v4l2.h
+++ b/fthd_v4l2.h
@@ -14,7 +14,6 @@
 #include <linux/spinlock.h>
 #include <linux/wait.h>
 #include <linux/mutex.h>
-#include <media/videobuf-dma-sg.h>
 #include <media/v4l2-device.h>
 
 struct fthd_fmt {


### PR DESCRIPTION
In linux-next commit [2a2fffb488a3](https://github.com/torvalds/linux/commit/2a2fffb488a3c5ea9c06d0b572c90c4aa78709b6) ("media: remove the old videobuf framework"), legacy videobuf framework has been removed, and causes builds to fail due to the lack of `include/media/videobuf-dma-sg.h`.