### PR TITLE
v4l2: accommodate to struct filed rename of vb2_buffer::min_buffers_needed

### DIFF
--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -683,7 +683,11 @@ int fthd_v4l2_register(struct fthd_private *dev_priv)
 	q->mem_ops = &vb2_dma_sg_memops;
 	q->buf_struct_size = 0;//sizeof(struct vpif_cap_buffer);
 	q->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
 	q->min_buffers_needed = 1;
+#else
+	q->min_queued_buffers = 1;
+#endif
 	q->lock = &dev_priv->vb2_queue_lock;
 
 	ret = vb2_queue_init(q);


### PR DESCRIPTION
Failed to build against v6.8-rc4 due to upstream kernel commit [80c2b40a5139](https://github.com/torvalds/linux/commit/80c2b40a5139) ("media: videobuf2: core: Rename min_buffers_needed field in vb2_queue"):
```
/var/lib/dkms/facetimehd/0.5.18/build/fthd_v4l2.c: In function ‘fthd_v4l2_register’:
/var/lib/dkms/facetimehd/0.5.18/build/fthd_v4l2.c:687:10: error: ‘struct vb2_queue’ has no member named ‘min_buffers_needed’
  687 |         q->min_buffers_needed = 1;
      |          ^~
make[2]: *** [scripts/Makefile.build:243: /var/lib/dkms/facetimehd/0.5.18/build/fthd_v4l2.o] Error 1
```