### PR TITLE
Update fthd_drv.c

### DIFF
--- a/fthd_drv.c
+++ b/fthd_drv.c
@@ -542,6 +542,7 @@ static struct pci_driver fthd_pci_driver = {
 	.name = KBUILD_MODNAME,
 	.probe = fthd_pci_probe,
 	.remove = fthd_pci_remove,
+	.shutdown = fthd_pci_remove,
 	.id_table = fthd_pci_id_table,
 #ifdef CONFIG_PM
 	.suspend = fthd_pci_suspend,


### PR DESCRIPTION
When running Linux in a VM with the facetimehd module, the device must explicitly be removed.

If the device is not removed upon a shutdown of the VM, the device becomes inoperable until a full reboot of the host. Inoperable here means that the error message "Init failed! No wake signal" occurs.

The wifi adaptor on my macbook also requires this patch, fyi: https://joshua.hu/brcmfmac-bcm43602-suspension-shutdown-hanging-freeze-linux-freebsd-wifi-bug-pci-passthru#linux