### PR TITLE
Update fthd_ddr.c for Linux Kernel 6.13+

### DIFF
--- a/fthd_ddr.c
+++ b/fthd_ddr.c
@@ -17,7 +17,13 @@
  *
  */
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 #include <linux/prandom.h>
+#else
+#include <linux/random.h>
+#endif
+
 #include "fthd_drv.h"
 #include "fthd_hw.h"
 #include "fthd_ddr.h"

--- a/fthd_ddr.c
+++ b/fthd_ddr.c
@@ -17,7 +17,7 @@
  *
  */
 
-#include <linux/random.h>
+#include <linux/prandom.h>
 #include "fthd_drv.h"
 #include "fthd_hw.h"
 #include "fthd_ddr.h"


### PR DESCRIPTION
Shipped in linux kernel 6.13, <linux/random.h> no longer includes <linux/prandom.h> [1]. This file depended on that nested include, and this commit changes the include to use that header directly. Without this, module compilation fails trying to use prandom_seed_state() which is in longer included.

If anyone stumbles upon this before there's an update, I forked an updated package[2] for arch linux.

[1]: https://github.com/torvalds/linux/commit/5b3fdc9f2ff10d3cee106ddaa0ee6636c7de381e
[2]: https://git.sr.ht/~jakintosh/facetimehd-dkms