### PR TITLE
v4l2: apply the control values userspace set before STREAMON

### DIFF
--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -1232,12 +1232,6 @@ int fthd_start_channel(struct fthd_private *dev_priv, int channel)
 	ret = fthd_isp_cmd_channel_streaming_mode(dev_priv, 0, 0);
 	if (ret)
 		return ret;
-	ret = fthd_isp_cmd_channel_brightness_set(dev_priv, 0, 0x80);
-	if (ret)
-		return ret;
-	ret = fthd_isp_cmd_channel_contrast_set(dev_priv, 0, 0x80);
-	if (ret)
-		return ret;
 	ret = fthd_isp_cmd_channel_start(dev_priv);
 	if (ret)
 		return ret;

--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -268,6 +268,9 @@ static int fthd_start_streaming(struct vb2_queue *vq, unsigned int count)
 	if (ret)
 		return ret;
 
+	/* Starting the channel resets the ISP, so push the control values down. */
+	v4l2_ctrl_handler_setup(&dev_priv->v4l2_ctrl_handler);
+
 	for(i = 0; i < FTHD_BUFFERS && count; i++, count--) {
 		ctx = dev_priv->h2t_bufs + i;
 		if (ctx->state != BUF_DRV_QUEUED)


### PR DESCRIPTION
`fthd_start_channel()` forces brightness and contrast to `0x80`, so every `VIDIOC_STREAMON` throws away whatever the application had set. `VIDIOC_G_CTRL` keeps reporting the value that was asked for, which is what makes it hard to see: the control reads back correctly while the ISP runs with the default.

Drop the two hardcoded commands and call `v4l2_ctrl_handler_setup()` once the channel is up. That covers saturation, hue and auto white balance too, which had the same problem.

**Measured** on a MacBookPro14,1 against a module built from clean master. One `open()`, four frames from the same file descriptor, 20 frames dropped between each so the exposure settles. Mean luma of the Y plane at 640x360:

```
brightness      set when           master r1   master r2   patched
40              before STREAMON        37.38       34.36      0.02
210             while streaming       119.36      116.77    116.37
40              while streaming         0.01        0.01      0.01
128 (default)   while streaming        37.46       33.61     34.29
```

Before the change, brightness 40 set **before** `STREAMON` gives the same picture as the *default* — not as 40. The third row is the negative control taken in the same run: the setting does work, it is only the pre-`STREAMON` value that is lost. The two master columns are the same module measured twice, interleaved with the patched one; absolute values move with the ambient light, the relation does not.

After the change, the first row matches the third rather than the fourth.

---

### The series

Seven PRs on this driver, all on master (`364b1c6`), all found while debugging a camera problem on a MacBookPro14,1:

| | |
|---|---|
| #328 | two small cleanups: missing `break`, hardcoded buffer count |
| **#329 (this one)** | control values discarded at every `VIDIOC_STREAMON` |
| #330 | `cmd.y1` never assigned in the crop command — one line |
| #331 | `ALIGN(width, 7)` aligns nothing; second commit re-does 545cb18 and **should wait** |
| #332 | one firmware timeout leaves the driver with no usable buffers |
| #333 | the camera writes in front of any buffer that is not page aligned |
| #334 | the auto-exposure wait: 1000 ms → 200 ms |

They can be taken in any order, with one exception: **the second commit of #331 should not be taken yet** — reasons in that PR.

*(Until 23 August there was a second exception: #328 and #334 both carried the same `mdelay` → `msleep` commit, so whichever merged first made the other conflict. I have dropped it from #328; it lives in #334. The seven are now independent of each other.)*

There is one more patch not sent yet: the channel-start crop returns the top left corner of the frame at any size below the sensor. It is measured and ready, and it sits on top of #330. I am holding it back rather than adding an eighth PR to the pile.
