### PR TITLE
v4l2: report the frame sizes the driver accepts (pairs with #347)

### DIFF
--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -428,7 +428,7 @@ static int fthd_v4l2_adjust_format(struct fthd_private *dev_priv,
 
 	pix->colorspace = V4L2_COLORSPACE_SRGB;
 	pix->field = V4L2_FIELD_NONE;
-	pix->width = ALIGN(pix->width, 7);
+	pix->width = ALIGN(pix->width, 8);
 
 	switch (pix->pixelformat) {
 /*

--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -564,9 +564,13 @@ static int fthd_v4l2_ioctl_enum_framesizes(struct file *filp, void *priv,
 	    sizes->pixel_format != V4L2_PIX_FMT_YVYU)
 		return -EINVAL;
 
-	sizes->type = V4L2_FRMSIZE_TYPE_DISCRETE;
-	sizes->discrete.width  = dev_priv->sensor_width  ? : FTHD_MAX_WIDTH;
-	sizes->discrete.height = dev_priv->sensor_height ? : FTHD_MAX_HEIGHT;
+	sizes->type = V4L2_FRMSIZE_TYPE_STEPWISE;
+	sizes->stepwise.min_width  = FTHD_MIN_WIDTH;
+	sizes->stepwise.max_width  = dev_priv->sensor_width  ? : FTHD_MAX_WIDTH;
+	sizes->stepwise.step_width = 8;
+	sizes->stepwise.min_height  = FTHD_MIN_HEIGHT;
+	sizes->stepwise.max_height  = dev_priv->sensor_height ? : FTHD_MAX_HEIGHT;
+	sizes->stepwise.step_height = 1;
 
 	return 0;
 }


### PR DESCRIPTION
**Rebased.** Thanks for cherry-picking the alignment fix — it is in master as `3cdb58b`, so it is
gone from here and this PR is now the one commit you asked to wait on.

**It re-does part of 545cb18** (May 2020), where you deliberately went back to discrete because
Skype could not handle a stepwise range — with the same `step_width = 8, step_height = 1`. I did
not find that before opening this, and the first version of this description cited #52 as support
when #52 is part of what led you to revert. Sorry for the noise.

### Why it is worth having

Since 545cb18 the driver advertises one size while `adjust_format()` accepts anything from
320x240 up to the sensor, with the scaler covering everything between. Applications that pick a
resolution from the enumeration never offer the smaller sizes. #243 (2021) and #323 (2026) are
both that, and both were opened *after* the revert.

On a MacBookPro14,1 the enumeration goes from `Discrete 1296x736` to
`Stepwise 320x240 - 1296x736 with step 8/1`, and `v4l2-compliance` 1.32.0 from
`test Scaling: FAIL` to `OK`.

While measuring that, I checked which PR fixes which compliance failure, since master currently
has three. `test Scaling` is this one. Both `CREATE_BUFS` failures are #342 — verified by applying
#342 on its own, which leaves 47 of 48 with only `Scaling` left. With this PR, #342 and #345
applied together the driver reaches **48 of 48, zero failures**.

### The userspace side has landed — and my prediction about it was wrong

All three userspace fixes are merged now:

* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2964 — merged
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2965 — merged
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2950 — merged 9 September,
  and cherry-picked to the stable 1.6 branch as `bcf371452`, so it will ship in 1.6.9, which is not released yet (the latest release is 1.6.8)

An earlier version of this description said that when !2950 landed, this PR would stop making the
camera worse. **That turned out to be wrong, and I measured it rather than assuming it.** !2950
makes a source offer the rectangle the device reports through `VIDIOC_G_SELECTION`, and
`facetimehd` does not implement the selection API, so it falls back to the smallest frame — which
is exactly the 320x240 case this PR would introduce.

The missing piece is on the driver side, and it is now #347: publish the sensor rectangle the
driver already reads from the firmware. Measured end to end through PipeWire master, with a client
that constrains only the media type:

| driver | enumeration | `CROP_BOUNDS` | client with no preference |
|---|---|---|---|
| master | Discrete 1296x736 | not implemented | 1296x736 |
| this PR alone | Stepwise 320x240 - 1296x736 | not implemented | **320x240** |
| this PR + #347 | Stepwise 320x240 - 1296x736 | 1296x736 | **1296x736** |

So the recommendation changes shape rather than going away: through PipeWire master this is
waiting on #347 rather than on userspace. Taken together the two make the camera better — honest
enumeration, `test Scaling` passing, and a preference-less client still getting the full sensor
frame. Taken alone, this one still costs 320x240.

On a released PipeWire, 1.6.8 or older, the change that reads the rectangle is not there yet, so a
preference-less client would still get 320x240 with both applied. That follows from the code; I
have not measured it.

### The rest of the series

Merged so far: #328, #329, #330, #332, #333. Open besides this one: #334, #338, #340, #342, #343,
#344, #345, and #347. They apply independently, with two exceptions: #344 contains the first
commit of #343, and this one should go in together with #347.
