### PR TITLE
The camera writes up to 4095 bytes in front of any buffer that is not page aligned

### DIFF
--- a/fthd_buffer.c
+++ b/fthd_buffer.c
@@ -42,8 +42,23 @@ struct iommu_obj *iommu_allocate_sgtable(struct fthd_private *dev_priv, struct s
 	int total_len = 0, dma_length;
 	dma_addr_t dma_addr;
 	
-	for(i = 0; i < sgtable->nents; i++)
-		total_len += sg_dma_len(sgtable->sgl + i);
+	for(i = 0; i < sgtable->nents; i++) {
+		sg = sgtable->sgl + i;
+
+		/* The IOMMU descriptor holds a page number only, so a segment
+		 * that does not start on a page boundary would be mapped from
+		 * the start of its page and the hardware would write up to
+		 * 4095 bytes in front of the buffer.
+		 */
+		if (sg->offset || (sg_dma_address(sg) & 0xfff)) {
+			dev_err(&dev_priv->pdev->dev,
+				"Buffer segment %d is not page aligned (offset %u), refusing\n",
+				i, sg->offset);
+			return NULL;
+		}
+
+		total_len += sg_dma_len(sg);
+	}
 	
 	if (!total_len)
 		return NULL;
@@ -73,9 +88,7 @@ struct iommu_obj *iommu_allocate_sgtable(struct fthd_private *dev_priv, struct s
 	pos = 0x9000 + obj->offset * 4;
 	for(i = 0; i < sgtable->nents; i++) {
 		sg = sgtable->sgl + i;
-		WARN_ON(sg->offset);
 		dma_addr = sg_dma_address(sg);
-		WARN_ON(dma_addr & 0xfff);
 		dma_addr >>= 12;
 		
 		for(dma_length = 0; dma_length < sg_dma_len(sg); dma_length += 0x1000) {

--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -705,7 +705,10 @@ int fthd_v4l2_register(struct fthd_private *dev_priv)
 
 	q = &dev_priv->vb2_queue;
 	q->type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-	q->io_modes = VB2_MMAP | VB2_USERPTR | VB2_DMABUF | VB2_READ;
+	/* VB2_USERPTR not supported due to missing support for unaligned
+	 * pointers.
+	 */
+	q->io_modes = VB2_MMAP | VB2_DMABUF | VB2_READ;
 	q->drv_priv = dev_priv;
 	q->ops = &vb2_queue_ops;
 	q->mem_ops = &vb2_dma_sg_memops;


### PR DESCRIPTION
The camera writes up to 4095 bytes **in front of** the buffer it was given, whenever that buffer does not start on a page boundary. The two `WARN_ON()`s meant to catch this only print and let the write happen.

**The mechanism.** `iommu_allocate_sgtable()` programs the S2 IOMMU one page at a time and keeps only the page number (`dma_addr >>= 12`), and the address `fthd_buffer_prepare()` hands the firmware is `(ctx->plane[0]->offset << 12)` at `fthd_v4l2.c:219`. The low twelve bits are zero by construction — there is nowhere on that path for an offset inside a page. A segment starting at offset X gets its *page* mapped, the firmware writes from the beginning of it, and the whole frame lands X bytes early.

**Measured** on a MacBookPro14,1 against a module built from clean master. A `USERPTR` buffer is placed a known distance past a page boundary with `0xA5` filled in front of it; the area is inside the process' own allocation, so nothing outside it is touched. After one frame:

```
offset   bytes destroyed in front   past end of buffer
  100            100                        0
 1000           1000                        0
 2048           2048                        0
 4000           3999                        0
```

One for one with the misalignment, so at the limit it is 4095. Both `WARN_ON()`s fire during the same run and the write happens anyway.

With `v4l2-compliance` 1.32.0, rotating three modules in one sitting: the out-of-bounds writes it reports go from 6132 to 0, and the two USERPTR tests go from `OK` — it prints the corruption and does not count it — to `FAIL` with the first commit, then to `not supported` with the second.

**Two commits.** Refuse a buffer the hardware cannot address; and stop advertising `VB2_USERPTR`, because V4L2 has no way to tell an application that its pointer must be page aligned, so the mode only ever worked when userspace happened to allocate on a boundary. **If you want only the first, say so and I will drop the second.**

`VB2_MMAP` is untouched — `vb2_dma_sg_alloc()` allocates whole pages, which is why every real application works today.

---

### The series

Seven PRs on this driver, all on master (`364b1c6`), all found while debugging a camera problem on a MacBookPro14,1:

| | |
|---|---|
| #328 | two small cleanups: missing `break`, hardcoded buffer count |
| #329 | control values discarded at every `VIDIOC_STREAMON` |
| #330 | `cmd.y1` never assigned in the crop command — one line |
| #331 | `ALIGN(width, 7)` aligns nothing; second commit re-does 545cb18 and **should wait** |
| #332 | one firmware timeout leaves the driver with no usable buffers |
| **#333 (this one)** | the camera writes in front of any buffer that is not page aligned |
| #334 | the auto-exposure wait: 1000 ms → 200 ms |

They can be taken in any order, with one exception: **the second commit of #331 should not be taken yet** — reasons in that PR.

*(Until 23 August there was a second exception: #328 and #334 both carried the same `mdelay` → `msleep` commit, so whichever merged first made the other conflict. I have dropped it from #328; it lives in #334. The seven are now independent of each other.)*

There is one more patch not sent yet: the channel-start crop returns the top left corner of the frame at any size below the sensor. It is measured and ready, and it sits on top of #330. I am holding it back rather than adding an eighth PR to the pile.
