### PR TITLE
isp: wait 200 ms for AE to settle, not a full second

### DIFF
--- a/fthd_isp.c
+++ b/fthd_isp.c
@@ -1241,7 +1241,7 @@ int fthd_start_channel(struct fthd_private *dev_priv, int channel)
 	ret = fthd_isp_cmd_channel_start(dev_priv);
 	if (ret)
 		return ret;
-	mdelay(1000); /* Needed to settle AE */
+	msleep(1000); /* Needed to settle AE */
 	return 0;
 }
 


### PR DESCRIPTION
The auto-exposure wait in `fthd_start_channel()` goes from `mdelay(1000)` to `msleep(200)`. It is paid on every `VIDIOC_STREAMON`, not once per open.

Two commits, because they do different things. **Measured** on a MacBookPro14,1, mean of five repetitions each against a module built from clean master, min and max in brackets:

```
                     STREAMON              system CPU burned
master               1078 ms [1077-1081]      986 ms [978-991]
+ msleep             1097 ms [1091-1103]        1 ms [1-1]
+ msleep + 200 ms     288 ms [287-294]           1 ms [0-1]
```

The `msleep` shortens nothing — it stops burning a CPU for the second. The 200 ms is what shortens the wait. Taking the value change without the `msleep` would mean 200 ms of a busy-held CPU instead of 1000, which is an improvement of the wrong kind, so both are here.

**Why 200.** The value has been 1000 ms since 2015 and there is nothing in the history behind it. Sweeping it as a module parameter, four interleaved repetitions per value with the light held constant, each run compared against its own final brightness: from 100 ms up the first frame already has the brightness the stream settles on; at 50 ms and below it comes out black. Repeated with 60 s of idle before each run so the exposure could not start from the previous state — 100 ms still good, three times out of three. 200 ms is twice the smallest value that worked.

Worth pointing at: a full second is not even the better choice. It delivers a first frame 10% brighter than where the stream settles, where 100 ms lands on it.

**What this does not cover.** One camera, and the measurement is of luma only — if the wait was also protecting the white balance, this would not have seen it. The driver also still waits blind rather than polling the firmware's `CISP_CMD_CH_AE_*` state; if someone who knows the ISP wants to replace the wait with a poll, this patch should be thrown away in favour of that.

---

### The series

One of nine open PRs on this driver; the others are #331, #338, #340, #342, #343, #344, #345 and #347. They apply independently, with two exceptions: #344 contains the first commit of #343, and #331 should go in together with #347.