### PR TITLE
v4l2: omit filling format description when >= v4.2

### DIFF
--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -376,16 +376,22 @@ static int fthd_v4l2_ioctl_querycap(struct file *filp, void *priv,
 static int fthd_v4l2_ioctl_enum_fmt_vid_cap(struct file *filp, void *priv,
 				   struct v4l2_fmtdesc *fmt)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)
 	char *desc = NULL;
+#endif
 
 	switch (fmt->index) {
 	case 0:
 		fmt->pixelformat = V4L2_PIX_FMT_YUYV;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)
 		desc = "YUYV";
+#endif
 		break;
 	case 1:
 		fmt->pixelformat = V4L2_PIX_FMT_YVYU;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)
 		desc = "YVYU";
+#endif
 		break;
 	/* We don't support the mplane yet
 	case 2:
@@ -398,7 +404,9 @@ static int fthd_v4l2_ioctl_enum_fmt_vid_cap(struct file *filp, void *priv,
 	}
 
 	fmt->type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,2,0)
 	strncpy(fmt->description, desc, sizeof(fmt->description));
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Since v4.2, format description is filled by `v4l_fill_fmtdesc`, and the vidioc_enum_fmt_* no longer have to fill that by themselves. While v7.2-rc1 commit [079a028d6327e](https://github.com/torvalds/linux/commit/079a028d6327e) ("string: Remove strncpy() from the kernel") removes strncpy that is used by facetimehd, it breaks builds against v7.2+ kernels.

Compliance tests after patched:
```
$ v4l2-compliance 
v4l2-compliance 1.32.0, 64 bits, 64-bit time_t

Compliance test for facetimehd device /dev/video0:

Driver Info:
        Driver name      : facetimehd
        Card type        : Apple Facetime HD
        Bus info         : PCI:0000:02:00.0
        Driver version   : 7.2.0
        Capabilities     : 0x85200001
                Video Capture
                Read/Write
                Streaming
                Extended Pix Format
                Device Capabilities
        Device Caps      : 0x05200001
                Video Capture
                Read/Write
                Streaming
                Extended Pix Format

Required ioctls:
        test VIDIOC_QUERYCAP: OK
        test invalid ioctls: OK

Allow for multiple opens:
        test second /dev/video0 open: OK
        test VIDIOC_QUERYCAP: OK
        test VIDIOC_G/S_PRIORITY: OK
        test for unlimited opens: OK

Debug ioctls:
        test VIDIOC_DBG_G/S_REGISTER: OK (Not Supported)
        test VIDIOC_LOG_STATUS: OK (Not Supported)

Input ioctls:
        test VIDIOC_G/S_TUNER/ENUM_FREQ_BANDS: OK (Not Supported)
        test VIDIOC_G/S_FREQUENCY: OK (Not Supported)
        test VIDIOC_S_HW_FREQ_SEEK: OK (Not Supported)
        test VIDIOC_ENUMAUDIO: OK (Not Supported)
        test VIDIOC_G/S/ENUMINPUT: OK
        test VIDIOC_G/S_AUDIO: OK (Not Supported)
        Inputs: 1 Audio Inputs: 0 Tuners: 0

Output ioctls:
        test VIDIOC_G/S_MODULATOR: OK (Not Supported)
        test VIDIOC_G/S_FREQUENCY: OK (Not Supported)
        test VIDIOC_ENUMAUDOUT: OK (Not Supported)
        test VIDIOC_G/S/ENUMOUTPUT: OK (Not Supported)
        test VIDIOC_G/S_AUDOUT: OK (Not Supported)
        Outputs: 0 Audio Outputs: 0 Modulators: 0

Input/Output configuration ioctls:
        test VIDIOC_ENUM/G/S/QUERY_STD: OK (Not Supported)
        test VIDIOC_ENUM/G/S/QUERY_DV_TIMINGS: OK (Not Supported)
        test VIDIOC_DV_TIMINGS_CAP: OK (Not Supported)
        test VIDIOC_G/S_EDID: OK (Not Supported)

Control ioctls (Input 0):
        test VIDIOC_QUERY_EXT_CTRL/QUERYMENU: OK
        test VIDIOC_QUERYCTRL: OK
        test VIDIOC_G/S_CTRL: OK
        test VIDIOC_G/S/TRY_EXT_CTRLS: OK
        test VIDIOC_(UN)SUBSCRIBE_EVENT/DQEVENT: OK
        test VIDIOC_G/S_JPEGCOMP: OK (Not Supported)
        Standard Controls: 6 Private Controls: 0

Format ioctls (Input 0):
        test VIDIOC_ENUM_FMT/FRAMESIZES/FRAMEINTERVALS: OK
        test VIDIOC_G/S_PARM: OK
        test VIDIOC_G_FBUF: OK (Not Supported)
        test VIDIOC_G_FMT: OK
        test VIDIOC_TRY_FMT: OK
        test VIDIOC_S_FMT: OK
        test VIDIOC_G_SLICED_VBI_CAP: OK (Not Supported)
        test Cropping: OK (Not Supported)
        test Composing: OK (Not Supported)
                fail: v4l2-test-formats.cpp(1967): node->can_scale && node->frmsizes_count[v4l_format_g_pixelformat(&cur)]
                fail: v4l2-test-formats.cpp(2036): testBasicScaling(node, fmt)
        test Scaling: FAIL

Codec ioctls (Input 0):
        test VIDIOC_(TRY_)ENCODER_CMD: OK (Not Supported)
        test VIDIOC_G_ENC_INDEX: OK (Not Supported)
        test VIDIOC_(TRY_)DECODER_CMD: OK (Not Supported)

Buffer ioctls (Input 0):
                fail: v4l2-test-buffers.cpp(822): doioctl(node, VIDIOC_CREATE_BUFS, &crbufs)
        test VIDIOC_REQBUFS/CREATE_BUFS/QUERYBUF: FAIL
                fail: v4l2-test-buffers.cpp(972): q.create_bufs(node, q.g_max_num_buffers())
        test CREATE_BUFS maximum buffers: FAIL
        test VIDIOC_REMOVE_BUFS: OK
        test VIDIOC_EXPBUF: OK
        test Requests: OK (Not Supported)
        test blocking wait: OK

Total for facetimehd device /dev/video0: 48, Succeeded: 45, Failed: 3, Warnings: 0
```