### PR TITLE
Make legacy suspend teardown safe

### DIFF
--- a/fthd_drv.c
+++ b/fthd_drv.c
@@ -325,6 +325,7 @@ static void fthd_pci_remove(struct pci_dev *pdev)
 	dev_priv = pci_get_drvdata(pdev);
 	if (!dev_priv)
 		goto out;
+	pci_set_drvdata(pdev, NULL);
 
 	fthd_debugfs_exit(dev_priv);
 
@@ -354,6 +355,7 @@ static void fthd_pci_remove(struct pci_dev *pdev)
 	pci_release_region(pdev, FTHD_PCI_S2_IO);
 	pci_release_region(pdev, FTHD_PCI_S2_MEM);
 	pci_release_region(pdev, FTHD_PCI_ISP_IO);
+	kfree(dev_priv);
 out:
 	pci_disable_device(pdev);
 }
@@ -471,6 +473,7 @@ static int fthd_pci_probe(struct pci_dev *pdev,
 	mutex_init(&dev_priv->vb2_queue_lock);
 
 	mutex_init(&dev_priv->ioctl_lock);
+	atomic_set(&dev_priv->users, 0);
 	INIT_LIST_HEAD(&dev_priv->buffer_queue);
 	INIT_WORK(&dev_priv->irq_work, fthd_irq_work);
 
@@ -525,6 +528,17 @@ fail_work:
 #ifdef CONFIG_PM
 static int fthd_pci_suspend(struct pci_dev *pdev, pm_message_t state)
 {
+	struct fthd_private *dev_priv = pci_get_drvdata(pdev);
+
+	/* Tearing down the firmware and DMA mappings under an open V4L2 file
+	 * leaves the file handle pointing at freed driver state.  Refuse the
+	 * transition instead of risking a use-after-free on resume. */
+	if (dev_priv && atomic_read(&dev_priv->users)) {
+		dev_warn(&pdev->dev,
+			 "camera is in use; close video applications before suspend\n");
+		return -EBUSY;
+	}
+
 	fthd_pci_remove(pdev);
 
 	return 0;
@@ -532,9 +546,7 @@ static int fthd_pci_suspend(struct pci_dev *pdev, pm_message_t state)
 
 static int fthd_pci_resume(struct pci_dev *pdev)
 {
-	fthd_pci_probe(pdev, NULL);
-
-	return 0;
+	return fthd_pci_probe(pdev, NULL);
 }
 #endif /* CONFIG_PM */
 

--- a/fthd_drv.h
+++ b/fthd_drv.h
@@ -54,7 +54,7 @@ struct fthd_private {
 	struct v4l2_device v4l2_dev;
 	struct video_device *videodev;
 	struct mutex ioctl_lock;
-	int users;
+	atomic_t users;
 	/* lock for synchronizing with irq/workqueue */
 	spinlock_t io_lock;
 

--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -319,12 +319,35 @@ static struct vb2_ops vb2_queue_ops = {
 #endif
 };
 
+static int fthd_v4l2_open(struct file *filp)
+{
+	struct fthd_private *dev_priv = video_drvdata(filp);
+	int ret;
+
+	ret = v4l2_fh_open(filp);
+	if (!ret)
+		atomic_inc(&dev_priv->users);
+
+	return ret;
+}
+
+static int fthd_v4l2_release(struct file *filp)
+{
+	struct fthd_private *dev_priv = video_drvdata(filp);
+	int ret;
+
+	ret = vb2_fop_release(filp);
+	atomic_dec(&dev_priv->users);
+
+	return ret;
+}
+
 static struct v4l2_file_operations fthd_vdev_fops = {
 	.owner          = THIS_MODULE,
-	.open           = v4l2_fh_open,
+	.open           = fthd_v4l2_open,
 
 	.read		= vb2_fop_read,
-	.release        = vb2_fop_release,
+	.release        = fthd_v4l2_release,
 	.poll           = vb2_fop_poll,
 	.mmap           = vb2_fop_mmap,
 	.unlocked_ioctl = video_ioctl2


### PR DESCRIPTION
## Summary

- track open V4L2 file handles and reject suspend while the camera is in use
- clear PCI driver data and free the old per-device allocation during teardown
- propagate probe failures from the resume callback

## Motivation

The legacy suspend callback currently invokes the complete remove path even when userspace still holds an open V4L2 handle. That can leave the handle referring to torn-down DMA and driver state. Each suspend cycle also leaks the old per-device allocation, and resume reports success even when reprobe fails.

This patch takes the conservative approach of returning `-EBUSY` while the camera is open. It does not attempt transparent suspend of an active stream.

## Testing

Tested on:

- MacBookAir7,2 (2017)
- Broadcom 1570 FaceTime HD camera
- Arch Linux / Omarchy
- Linux 7.1.8-arch1-3

Results:

- module builds successfully against Linux 7.1.8
- idle deep suspend/resume succeeds and `/dev/video0` works afterward
- while mpv is streaming, both deep and s2idle suspend are rejected with `-EBUSY` instead of tearing down active camera state
- camera continues streaming after the rejected suspend attempt